### PR TITLE
Removed protocol relative URL for jQuery and added charset / type="text/javascript"

### DIFF
--- a/src/MaterializeCSSBuilder.php
+++ b/src/MaterializeCSSBuilder.php
@@ -13,7 +13,7 @@
 
         public static function include_full() {
             $return  = self::include_css();
-            $return .= self::tag_js('//code.jquery.com/'.self::$file_jquery);
+            $return .= self::tag_js('https://code.jquery.com/'.self::$file_jquery);
             $return .= self::include_js();
             return $return;
         }
@@ -61,11 +61,11 @@
         }
 
         private static function tag_css($path) {
-            return '<link rel="stylesheet" href="'.$path.'">';
+            return '<link rel="stylesheet" charset="utf-8" href="'.$path.'">';
         }
 
         private static function tag_js($path) {
-            return '<script src="'.$path.'"></script>';
+            return '<script type="text/javascript" src="'.$path.'"></script>';
         }
 
     }


### PR DESCRIPTION
Nowadays the tendency of the web is to move to HTTPS, so the use of protocol-relative URLs has become an anti-pattern therefor I make this commit to update the codebase to reflect this. 

Furthermore, I have added charset="utf-8" and type="text/javascript" to tag_css and tag_js as to follow best practice.

Thanks for a otherwise great package 